### PR TITLE
Sync focus styles

### DIFF
--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -65,7 +65,7 @@ ilw-footer {
         color: var(--ilw-link--focus-color);
         background-color: var(--ilw-link--focus-background-color);
         outline: var(--ilw-link--focus-outline);
-        text-decoration-thickness: 0.1em;
+        text-decoration-thickness: 0.1rem;
     }
 
     /* Primary unit */
@@ -97,7 +97,7 @@ ilw-footer {
         color: var(--ilw-link--focus-color);
         background-color: var(--ilw-link--focus-background-color);
         outline: var(--ilw-link--focus-outline);
-        text-decoration-thickness: 0.1em;
+        text-decoration-thickness: 0.1rem;
     }
 
     /* Social media */
@@ -149,8 +149,10 @@ ilw-footer {
         }
 
         a:focus {
-            background-image: var(--ilw-footer-social-icon-hover);
-            outline: 2px dotted var(--il-blue);
+            color: var(--ilw-link--focus-color);
+            background-color: var(--ilw-link--focus-background-color);
+            outline: var(--ilw-link--focus-outline);
+            outline-width: 0.2rem;
         }
 
         a[data-service="bluesky"],

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -82,15 +82,18 @@ ilw-footer {
     }
 
     a[slot="primary-unit"]:hover,
-    *[slot="primary-unit"] a:hover {
+    *[slot="primary-unit"] a:hover,
+    a[slot="primary-unit"]:focus,
+    *[slot="primary-unit"] a:focus {
         text-decoration: underline;
-        color: var(--il-altgeld);
     }
 
     a[slot="primary-unit"]:focus,
     *[slot="primary-unit"] a:focus {
-        color: var(--il-altgeld);
-        outline: 2px dotted;
+        color: var(--ilw-link--focus-color);
+        background-color: var(--ilw-link--focus-background-color);
+        outline: var(--ilw-link--focus-outline);
+        text-decoration-thickness: 0.1em;
     }
 
     /* Social media */

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -34,6 +34,10 @@ ilw-footer {
         padding: 0;
     }
 
+    address a:hover {
+        color: var(--il-altgeld);
+    }
+
     /* Site name */
 
     *[slot="site-name"] {

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -10,7 +10,7 @@ ilw-footer {
 
     a:hover,
     a:focus {
-        color: var(--il-altgeld);
+        /* color: var(--il-altgeld); */
         text-decoration: underline;
         cursor: pointer;
     }

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -10,7 +10,6 @@ ilw-footer {
 
     a:hover,
     a:focus {
-        /* color: var(--il-altgeld); */
         text-decoration: underline;
         cursor: pointer;
     }
@@ -19,6 +18,7 @@ ilw-footer {
         color: var(--ilw-link--focus-color);
         background-color: var(--ilw-link--focus-background-color);
         outline: var(--ilw-link--focus-outline);
+        text-decoration-thickness: 0.1em;
     }
 
     address {
@@ -50,14 +50,18 @@ ilw-footer {
     }
 
     a[slot="site-name"]:hover,
-    *[slot="site-name"] a:hover {
+    *[slot="site-name"] a:hover,
+    a[slot="site-name"]:focus,
+    *[slot="site-name"] a:focus {
         text-decoration: underline;
-        color: var(--il-altgeld);
     }
 
     a[slot="site-name"]:focus,
     *[slot="site-name"] a:focus {
-        outline: 2px dotted;
+        color: var(--ilw-link--focus-color);
+        background-color: var(--ilw-link--focus-background-color);
+        outline: var(--ilw-link--focus-outline);
+        text-decoration-thickness: 0.1em;
     }
 
     /* Primary unit */

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -8,6 +8,19 @@ ilw-footer {
         text-decoration: underline;
     }
 
+    a:hover,
+    a:focus {
+        color: var(--il-altgeld);
+        text-decoration: underline;
+        cursor: pointer;
+    }
+
+    a:focus {
+        color: var(--ilw-link--focus-color);
+        background-color: var(--ilw-link--focus-background-color);
+        outline: var(--ilw-link--focus-outline);
+    }
+
     address {
         all: inherit;
         display: block;
@@ -19,15 +32,6 @@ ilw-footer {
         display: block;
         margin: 0;
         padding: 0;
-    }
-
-    address a {
-        color: var(--il-blue);
-    }
-
-    a:hover,
-    a:focus {
-        color: var(--il-altgeld);
     }
 
     /* Site name */

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -18,7 +18,7 @@ ilw-footer {
         color: var(--ilw-link--focus-color);
         background-color: var(--ilw-link--focus-background-color);
         outline: var(--ilw-link--focus-outline);
-        text-decoration-thickness: 0.1em;
+        text-decoration-thickness: 0.1rem;
     }
 
     address {
@@ -310,6 +310,23 @@ ilw-footer {
             display: block;
             margin: 12px 0 0;
             font: 400 18px/25px var(--il-font-sans);
+        }
+
+        a {
+            text-decoration: none;
+        }
+
+        a:hover,
+        a:focus {
+            text-decoration: underline;
+            cursor: pointer;
+        }
+
+        a:focus {
+            color: var(--ilw-link--focus-color);
+            background-color: var(--ilw-link--focus-background-color);
+            outline: var(--ilw-link--focus-outline);
+            text-decoration-thickness: 0.1rem;
         }
     }
 }

--- a/src/ilw-footer.styles.css
+++ b/src/ilw-footer.styles.css
@@ -124,7 +124,10 @@
 }
 
 .campus a:focus {
-    outline: 2px dotted;
+    fill: var(--ilw-link--focus-color);
+    background-color: var(--ilw-link--focus-background-color);
+    outline: var(--ilw-link--focus-outline);
+    color: var(--il-blue)
 }
 
 .legal.section-container {
@@ -141,8 +144,15 @@
     text-decoration: underline;
 }
 
-.legal a:focus {
+.legal a:hover {
     outline: 2px dotted;
+}
+
+.legal a:focus {
+    fill: var(--ilw-link--focus-color);
+    background-color: var(--ilw-link--focus-background-color);
+    outline: var(--ilw-link--focus-outline);
+    color: var(--il-blue);
 }
 
 .cookies-button-and-links {


### PR DESCRIPTION
## Summary

- adds standard WIGG focus styles to footer links (closes #5)

## Testing

0. From project root, run `npm run dev`
1. Open browser to sample page. (<http://localhost:5173/samples/with-menus.html> contains most link types.)
2. Check that links in each region:
    - match WIGG hover state
    - match WIGG focus state
    - have appropriate color contrast