### PR TITLE
Add utm code

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,16 @@ To add a cookie button, use the cookies button slot (`cookies-button`) and inclu
 </ilw-footer>
 ```
 
+### Custom Source Identifier
+
+Links in the campus footer section (those added and maintained as part of the campus brand) contain a UTM code for better analysis of brand implementation. You may set a custom UTM source to distinguish your site's traffic within those reports. If no source is set, the default value (`Illinois_App`) will be used.
+
+```html
+<ilw-footer source="Sample_Site">
+  <p slot="site-name">Sample Site</p>
+</ilw-footer>
+```
+
 ## External References
 
 - [HTML Anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a)

--- a/samples/custom-source.html
+++ b/samples/custom-source.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> 
+  <meta name="viewport" content="width=device-width, initial-scale=1"> 
+  <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico"> 
+  <link rel="dns-prefetch" href="//cdn.toolkit.illinois.edu">
+  <link rel="stylesheet" href="//cdn.toolkit.illinois.edu/3/toolkit.css">
+  <script type="module" src="/src/ilw-footer.ts"></script>
+  <title>Sample footer</title>
+</head>
+
+<body style="margin: 0; padding: 0;">
+  <main>
+    <h1>Footer with only a site name</h1>
+  </main>
+
+  <ilw-footer source="Example_Site">
+    <p slot="site-name"><a href="http://example.com/">Example Site Name</a></p>
+  </ilw-footer>
+</body>
+
+</html>

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -11,14 +11,19 @@ export class Footer extends LitElement {
 
   @property({
     attribute: true,
-    type: String
+    reflect: true,
   })
-  source?: string
+  source: string
 
   @property({
     attribute: false
   })
   _data?: CampusFooterData;
+
+  @property({
+    attribute: false,
+  })
+  _utm?: string
 
   static get styles() {
     return unsafeCSS(styles);
@@ -33,6 +38,7 @@ export class Footer extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.loadData();
+    this._utm = this.generateUtm();
   }
 
   async loadData() {
@@ -53,7 +59,7 @@ export class Footer extends LitElement {
 
   renderCampusLinks(links: CampusLink[]) {
     const listItems = links.map(link => {
-      return html`<li><a href="${link.href}">${link.label}</a></li>`
+      return html`<li><a href="${link.href}?${this._utm}">${link.label}</a></li>`
     })
     return html`<ul>${listItems}</ul>`;
   }
@@ -122,6 +128,11 @@ export class Footer extends LitElement {
           ${this.renderLegalFooter()}
         </footer>
       `
+  }
+
+  private generateUtm(): string {
+    const utm = `utm_source=${this.source}&utm_medium=web&utm_campaign=Footer`;
+    return utm;
   }
 }
 

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -7,6 +7,14 @@ import { property } from "lit/decorators.js";
 import { CampusFooterData, CampusFooterSection, CampusLink } from "./models/campus-footer-data";
 
 export class Footer extends LitElement {
+  private readonly _defaultSource = 'Illinois_App';
+
+  @property({
+    attribute: true,
+    type: String
+  })
+  source?: string
+
   @property({
     attribute: false
   })
@@ -18,6 +26,7 @@ export class Footer extends LitElement {
 
   constructor() {
     super();
+    this.source = this._defaultSource;
     this._data = undefined;
   }
 

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -69,7 +69,7 @@ export class Footer extends LitElement {
         <div class="campus section-container">
           <div class="campus section">
             <h2 class="logo">
-              <a href="https://illinois.edu/">${wordmark}</a>
+              <a href="https://illinois.edu/?${this._utm}">${wordmark}</a>
             </h2>
             ${this.renderCampusSections()}
           </div>
@@ -82,9 +82,9 @@ export class Footer extends LitElement {
           <div class="legal section">
             <div class="cookies-button-and-links">
               <slot name="cookies-button"></slot>
-              <a href="https://www.vpaa.uillinois.edu/resources/web_privacy">Privacy</a></li>
-              <a href="https://illinois.edu/resources/website/copyright.html">Copyright</a></li>
-              <a href="https://illinois.edu/resources/website/accessibility.html">Accessibility</a></li>
+              <a href="https://www.vpaa.uillinois.edu/resources/web_privacy?${this._utm}">Privacy</a></li>
+              <a href="https://illinois.edu/resources/website/copyright.html?${this._utm}">Copyright</a></li>
+              <a href="https://illinois.edu/resources/website/accessibility.html?${this._utm}">Accessibility</a></li>
             </div>
           </div>
         </div>`;

--- a/tests/footer.tests.js
+++ b/tests/footer.tests.js
@@ -29,3 +29,27 @@ test('component handles inheritance gracefully', async ({ page }) => {
 
   expect(tester).not.toBeNull();
 })
+
+test('campus links use utm with default value', async ({ page }) => {
+  const expected = 'utm_source=Illinois_App&utm_medium=web&utm_campaign=Footer';
+
+  await page.goto('samples/index.html');
+  const actual = await page.locator('.campus.section .section')
+    .getByRole('link')
+    .first()
+    .getAttribute('href')
+
+  expect(actual).toContain(expected);
+})
+
+test('custom source reflected in utm values', async ({ page }) => {
+  const expected = 'utm_source=Example_Site&utm_medium=web&utm_campaign=Footer';
+
+  await page.goto('samples/custom-source.html');
+  const actual = await page.locator('.campus.section .section')
+    .getByRole('link')
+    .first()
+    .getAttribute('href')
+
+  expect(actual).toContain(expected);
+})

--- a/tests/footer.tests.js
+++ b/tests/footer.tests.js
@@ -34,22 +34,18 @@ test('campus links use utm with default value', async ({ page }) => {
   const expected = 'utm_source=Illinois_App&utm_medium=web&utm_campaign=Footer';
 
   await page.goto('samples/index.html');
-  const actual = await page.locator('.campus.section .section')
-    .getByRole('link')
-    .first()
-    .getAttribute('href')
-
-  expect(actual).toContain(expected);
+  await page.getByRole('link')
+    .all(l => {
+      expect(l.getAttribute('href')).toContain(expected);
+    }, expected);
 })
 
 test('custom source reflected in utm values', async ({ page }) => {
   const expected = 'utm_source=Example_Site&utm_medium=web&utm_campaign=Footer';
 
-  await page.goto('samples/custom-source.html');
-  const actual = await page.locator('.campus.section .section')
-    .getByRole('link')
-    .first()
-    .getAttribute('href')
-
-  expect(actual).toContain(expected);
+  await page.goto('samples/index.html');
+  await page.getByRole('link')
+    .all(l => {
+      expect(l.getAttribute('href')).toContain(expected);
+    }, expected);
 })


### PR DESCRIPTION
## Summary

- Adds utm source attribute with default value (closes #13)
- Appends utm code to all managed links

## Testing

0. Run `npm test`
1. Run `npm dev` and open browser to a sample page (e.g., `{host}/samples/index.html`).
    a. Check that all footer default links contain the appropriate utm code
    b. Update the sample source attribute and check that the utm value changes