### PR TITLE
Raise footer menus if no action links defined

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@illinois-toolkit/ilw-footer",
-    "version": "1.2.3-alpha.0",
+    "version": "1.2.3-alpha.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@illinois-toolkit/ilw-footer",
-            "version": "1.2.3-alpha.0",
+            "version": "1.2.3-alpha.1",
             "license": "MIT",
             "dependencies": {
                 "lit": "3.1.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@illinois-toolkit/ilw-footer",
-    "version": "1.2.1",
+    "version": "1.2.3-alpha.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@illinois-toolkit/ilw-footer",
-            "version": "1.2.1",
+            "version": "1.2.3-alpha.0",
             "license": "MIT",
             "dependencies": {
                 "lit": "3.1.3"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "repository": "github:web-illinois/ilw-footer",
     "private": false,
     "license": "MIT",
-    "version": "1.2.2",
+    "version": "1.2.3-alpha.0",
     "type": "module",
     "files": [
         "src/**",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "repository": "github:web-illinois/ilw-footer",
     "private": false,
     "license": "MIT",
-    "version": "1.2.3-alpha.0",
+    "version": "1.2.3-alpha.1",
     "type": "module",
     "files": [
         "src/**",

--- a/samples/with-menus.html
+++ b/samples/with-menus.html
@@ -54,6 +54,10 @@
 
     <p slot="primary-unit"><a href="/">Strategic Communications and Marketing</a></p>
 
+    <div slot="actions">
+      <a href="/give">Give</a>
+      <a href="/apply">Apply</a>
+    </div>
 
     <nav class="ilw-footer-menu" aria-labelledby="menu-1">
       <h2 id="menu-1">First Menu</h2>

--- a/samples/with-menus.html
+++ b/samples/with-menus.html
@@ -54,10 +54,6 @@
 
     <p slot="primary-unit"><a href="/">Strategic Communications and Marketing</a></p>
 
-    <div slot="actions">
-      <a href="/give">Give</a>
-      <a href="/apply">Apply</a>
-    </div>
 
     <nav class="ilw-footer-menu" aria-labelledby="menu-1">
       <h2 id="menu-1">First Menu</h2>

--- a/src/ilw-footer.styles.css
+++ b/src/ilw-footer.styles.css
@@ -197,7 +197,10 @@
     /* bump content to top row if no actions slotted */
     .section-grid--no-action {
         & .content {
-            grid-area: 1 / 2 / 3 / 4;
+            grid-row-start: 1;
+            grid-row-end: 4;
+            grid-column-start: 2;
+            grid-column-end: 2;
         }
     }
 

--- a/src/ilw-footer.styles.css
+++ b/src/ilw-footer.styles.css
@@ -33,21 +33,35 @@
     margin: 0 var(--ilw-margin--side, 0);
 }
 
-.site.section {
+.section-grid {
     display: grid;
     grid-template-columns: auto;
     grid-auto-rows: auto auto auto auto;
-    grid-template-areas: "site-name" "address" "actions" "content";
+    grid-template-areas: "site-name" "contact" "actions" "content";
     grid-gap: 27px;
 }
 
-.site.section .site-name {
+.section-grid--no-action {
+    /* bump content to top row if no actions slotted */
+    grid-auto-rows: auto auto auto;
+    grid-template-areas: "site-name" "contact" "content";
+}
+
+.section-grid .contact {
+    grid-area: contact;
+}
+
+.section-grid .site-name {
     grid-area: site-name;
 }
 
-.site.section .actions {
+.section-grid .actions {
     grid-area: actions;
     justify-self: start;
+}
+
+.section-grid .content {
+    grid-area: content;
 }
 
 .campus.section-container {
@@ -77,7 +91,7 @@
 }
 
 .campus .logo a:hover {
-outline: 2px dotted;    
+    outline: 2px dotted;
 }
 
 .campus svg .illinois {
@@ -131,7 +145,7 @@ outline: 2px dotted;
     fill: var(--ilw-link--focus-color);
     background-color: var(--ilw-link--focus-background-color);
     outline: var(--ilw-link--focus-outline);
-    color: var(--il-blue)
+    color: var(--il-blue);
 }
 
 .legal.section-container {
@@ -174,14 +188,23 @@ outline: 2px dotted;
 }
 
 @container (min-width: 960px) {
-    .site.section {
+    .section-grid {
         grid-template-columns: 1fr 2fr;
         grid-auto-rows: auto auto;
-        grid-template-areas: "site-name actions" "address content";
+        grid-template-areas: "site-name actions" "contact content";
     }
-    .site.section .actions {
+
+    /* bump content to top row if no actions slotted */
+    .section-grid--no-action {
+        & .content {
+            grid-area: 1 / 2 / 3 / 4;
+        }
+    }
+
+    .section-grid .actions {
         justify-self: end;
     }
+
     .campus .sections {
         grid-template-columns: 1fr 1fr 1fr;
     }

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -1,10 +1,12 @@
-import { CSSResult, CSSResultGroup, LitElement, PropertyValues, html, unsafeCSS } from "lit";
+import { CSSResult, CSSResultGroup, LitElement, PropertyValues, css, html, unsafeCSS } from "lit";
 // @ts-ignore
 import styles from './ilw-footer.styles.css?inline';
 import './ilw-footer.css';
 import { default as wordmark } from "./wordmark.svg"
 import { property, queryAssignedElements } from "lit/decorators.js";
 import { CampusFooterData, CampusFooterSection, CampusLink } from "./models/campus-footer-data";
+import { classMap } from 'lit/directives/class-map.js';
+import { styleMap } from 'lit/directives/style-map.js';
 
 export class Footer extends LitElement {
   private readonly _defaultSource = 'Illinois_App';
@@ -27,6 +29,11 @@ export class Footer extends LitElement {
 
   @queryAssignedElements({ slot: 'actions' })
   _actions?: Array<HTMLDivElement>;
+
+  @property({
+    attribute: false
+  })
+  _sectionClasses = { 'section-grid': true, 'section-grid--no-action': false }
 
   static get styles(): CSSResultGroup {
     return unsafeCSS(styles);
@@ -97,7 +104,7 @@ export class Footer extends LitElement {
     // site name, social media icons, address, phone, email,  primary unit.
     return html`
         <div class="site section-container">
-          <div class="site section">
+          <div class="site section ${classMap(this._sectionClasses)}">
             <div class="site-name">
               <slot name="site-name"></slot>
             </div>
@@ -158,6 +165,7 @@ export class Footer extends LitElement {
 
   private redefineGridLayout(): void {
     console.debug('redefining grid layout');
+    this._sectionClasses["section-grid--no-action"] = true;
   }
 }
 

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -1,4 +1,4 @@
-import { CSSResult, LitElement, PropertyValues, html, unsafeCSS } from "lit";
+import { CSSResult, CSSResultGroup, LitElement, PropertyValues, html, unsafeCSS } from "lit";
 // @ts-ignore
 import styles from './ilw-footer.styles.css?inline';
 import './ilw-footer.css';
@@ -28,7 +28,7 @@ export class Footer extends LitElement {
   @queryAssignedElements({ slot: 'actions' })
   _actions?: Array<HTMLDivElement>;
 
-  static get styles(): CSSResult | CSSResult[] {
+  static get styles(): CSSResultGroup {
     return unsafeCSS(styles);
   }
 

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -142,7 +142,8 @@ export class Footer extends LitElement {
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
     if (this._actions === undefined || this._actions.length <= 0 || this._actions[0].children.length <= 0) {
-      this._sectionClasses["section-grid--no-action"];
+      console.debug('switching section classes')
+      this._sectionClasses["section-grid--no-action"] = true;
     }
   }
 

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -33,7 +33,7 @@ export class Footer extends LitElement {
   @property({
     attribute: false
   })
-  _sectionClasses = { 'section-grid': true, 'section-grid--no-action': false }
+  _sectionClasses = { 'section-grid--no-action': false }
 
   static get styles(): CSSResultGroup {
     return unsafeCSS(styles);
@@ -104,7 +104,7 @@ export class Footer extends LitElement {
     // site name, social media icons, address, phone, email,  primary unit.
     return html`
         <div class="site section-container">
-          <div class="site section ${classMap(this._sectionClasses)}">
+          <div class="site section section-grid ${classMap(this._sectionClasses)}">
             <div class="site-name">
               <slot name="site-name"></slot>
             </div>
@@ -141,24 +141,14 @@ export class Footer extends LitElement {
   }
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
-    if (this._actions === null || this._actions === undefined || this._actions.length <= 0) {
-      this.redefineGridLayout();
-      return;
-    }
-
-    const slot = this._actions[0] as HTMLDivElement;
-    if (slot.children.length <= 0) {
-      this.redefineGridLayout();
+    if (this._actions === undefined || this._actions.length <= 0 || this._actions[0].children.length <= 0) {
+      this._sectionClasses["section-grid--no-action"];
     }
   }
 
   private generateUtm(): string {
     const utm = `utm_source=${this.source}&utm_medium=web&utm_campaign=Footer`;
     return utm;
-  }
-
-  private redefineGridLayout(): void {
-    this._sectionClasses["section-grid--no-action"] = true;
   }
 }
 

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -1,9 +1,9 @@
-import { CSSResult, LitElement, html, unsafeCSS } from "lit";
+import { CSSResult, LitElement, PropertyValues, html, unsafeCSS } from "lit";
 // @ts-ignore
 import styles from './ilw-footer.styles.css?inline';
 import './ilw-footer.css';
 import { default as wordmark } from "./wordmark.svg"
-import { property } from "lit/decorators.js";
+import { property, queryAssignedElements } from "lit/decorators.js";
 import { CampusFooterData, CampusFooterSection, CampusLink } from "./models/campus-footer-data";
 
 export class Footer extends LitElement {
@@ -24,6 +24,9 @@ export class Footer extends LitElement {
     attribute: false,
   })
   _utm?: string
+
+  @queryAssignedElements({ slot: 'actions' })
+  _actions?: Array<HTMLDivElement>;
 
   static get styles(): CSSResult | CSSResult[] {
     return unsafeCSS(styles);
@@ -130,9 +133,31 @@ export class Footer extends LitElement {
       `
   }
 
+  protected firstUpdated(_changedProperties: PropertyValues): void {
+    const actions = this._actions;
+    console.debug({ actions });
+    if (this._actions === null || this._actions === undefined || this._actions.length <= 0) {
+      console.debug('actions is empty. redefine grid');
+      this.redefineGridLayout();
+      return;
+    }
+
+    const slot = this._actions[0] as HTMLDivElement;
+    console.debug({ slot });
+
+    if (slot.children.length <= 0) {
+      console.debug('no actions. redefine grid');
+      this.redefineGridLayout();
+    }
+  }
+
   private generateUtm(): string {
     const utm = `utm_source=${this.source}&utm_medium=web&utm_campaign=Footer`;
     return utm;
+  }
+
+  private redefineGridLayout(): void {
+    console.debug('redefining grid layout');
   }
 }
 

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -141,19 +141,13 @@ export class Footer extends LitElement {
   }
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
-    const actions = this._actions;
-    console.debug({ actions });
     if (this._actions === null || this._actions === undefined || this._actions.length <= 0) {
-      console.debug('actions is empty. redefine grid');
       this.redefineGridLayout();
       return;
     }
 
     const slot = this._actions[0] as HTMLDivElement;
-    console.debug({ slot });
-
     if (slot.children.length <= 0) {
-      console.debug('no actions. redefine grid');
       this.redefineGridLayout();
     }
   }
@@ -164,7 +158,6 @@ export class Footer extends LitElement {
   }
 
   private redefineGridLayout(): void {
-    console.debug('redefining grid layout');
     this._sectionClasses["section-grid--no-action"] = true;
   }
 }


### PR DESCRIPTION
## Summary

- Check whether links have been defined in action slot
- If no actions defined, raise remaining content to top of column 2 (closes #18)
- Redefines `styles()` return type as `CSSResultGroup` (see typescript note in https://lit.dev/docs/components/styles/#inheriting-styles-from-a-superclass)

## Testing

0. Run `npm run dev` and open browser to sample pages (e.g., <http://localhost:5173/samples/with-menus>).
    * check that default desktop layout matches production version
    * check that default mobile layout matches production version (single column)
1. Remove `<div slot="actions">[...]</div>` from sample pages
    * check that column 2 content moves to top of content
    * check that mobile layout still displays as single column