### PR TITLE
Social media icon service deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,26 +71,26 @@ is recommended.
 
     <nav slot="social" aria-label="Social media">
       <ul>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>  
+        <li><a href="http://example.com/"><ilw-icon alt="Our Bluesky account" icon="bluesky" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our events calendar account" icon="calendar" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Facebook account" icon="facebook" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Flickr account" icon="flickr" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our GitHub account" icon="github" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Instagram account" icon="instagram" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our LinkedIn account" icon="linkedin" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Mastodon account" icon="mastodon" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Pinterest account" icon="pinterest" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Reddit account" icon="reddit" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Snapchat account" icon="snapchat" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Spotify account" icon="spotify" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Threads account" icon="threads" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our TikTok account" icon="tiktok" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Twitter account" icon="twitter" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Weibo account" icon="weibo" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our WhatsApp account" icon="whatsapp" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our X account" icon="x" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Yelp account" icon="yelp" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our YouTube account" icon="youtube" size="44px"></ilw-icon></a></li>
       </ul>
     </nav>
 </ilw-footer>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ is recommended.
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The footer component defines an area at the bottom of the page which should cont
 |-------------------------|------------------------------------------------------------------|
 | `slot="primary-unit"`   | Assigns unit name to left column.                                |
 | `slot="site-name"`      | Assigns site name to left column.                                |
-| `slot="address"`        | Assigns address to left column.                                  |
+| `slot="address"`        | Assigns address to left column. (Note icon **DEPRECATION**.)     |
 | `slot="social"`         | Assigns social media links to left column.                       |
 | `slot="actions"`        | Assigns call to action links to right column.                    |
 | `slot="cookies-button"` | **DEPRECATED** Includes cookie banner and button in lower edge.  |
@@ -60,10 +60,10 @@ The footer contains slots for site name (`site-name`), primary unit (`primary-un
 
 ### Social Media
 
-The social media slot (`social`) should be used for social media links. Icons for supported sites may be added using the `data-service` attribute.
+The social media slot (`social`) should be used for social media links. The use of [ilw-icon components](https://github.com/web-illinois/ilw-icon)
+is recommended.
 
-Social media icons are drawn from the official campus icon set (<https://cdn.brand.illinois.edu/icons.html>).
-Icons for unsupported sites may be added by targeting the `social` slot adding the necessary inline style rules to the unsupported link.
+**DEPRECATED:** Automated icon support using the `data-service` attribute is deprecated.
 
 ```html
 <ilw-footer>
@@ -71,27 +71,26 @@ Icons for unsupported sites may be added by targeting the `social` slot adding t
 
     <nav slot="social" aria-label="Social media">
       <ul>
-        <li><a data-service="bluesky" href="http://example.com/">Bluesky</a></li>
-        <li><a data-service="calendar" href="http://example.com/">Calendar</a></li>
-        <li><a data-service="facebook" href="http://example.com/">Facebook</a></li>
-        <li><a data-service="flickr" href="http://example.com/">flickr</a></li>
-        <li><a data-service="github" href="http://example.com/">GitHub</a></li>
-        <li><a data-service="instagram" href="http://example.com/">Instagram</a></li>
-        <li><a data-service="linkedin" href="http://example.com/">LinkedIn</a></li>
-        <li><a data-service="mastodon" href="http://example.com/">Mastodon</a></li>
-        <li><a data-service="pinterest" href="http://example.com/">Pinterest</a></li>
-        <li><a data-service="reddit" href="http://example.com/">Reddit</a></li>
-        <li><a data-service="snapchat" href="http://example.com/">Snapchat</a></li>
-        <li><a data-service="spotify" href="http://example.com/">Spotify</a></li>
-        <li><a data-service="threads" href="http://example.com/">Threads</a></li>
-        <li><a data-service="tiktok" href="http://example.com/">TikTok</a></li>
-        <li><a data-service="twitter" href="http://example.com/">Twitter</a></li>
-        <li><a data-service="weibo" href="http://example.com/">Weibo</a></li>
-        <li><a data-service="whatsapp" href="http://example.com/">WhatsApp</a></li>
-        <li><a data-service="x" href="http://example.com/">X</a></li>
-        <li><a data-service="yelp" href="http://example.com/">Yelp</a></li>
-        <li><a data-service="youtube" href="http://example.com/">YouTube</a></li>
-        <li><a href="#" style="--ilw-footer-social-icon: url('blue.svg'); --ilw-footer-social-icon-hover: url('orange.svg');">Custom Site</a></li>  
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>  
       </ul>
     </nav>
 </ilw-footer>
@@ -207,6 +206,8 @@ Links in the campus footer section (those added and maintained as part of the ca
 ## Deprecations
 
 **Cookies button slot:** The Illinois cookie button and script are now included by default. During the deprecation period, existing cookie buttons will be honored. Remove references to `slot="cookies-button"`.
+
+**Social icon data-service:** Automated social media icon selection using the link's `data-service` attribute is no longer recommended. Existing `data-service`-enabled links will be honored during the deprecation period. Update links by removing `data-service="icon"` and replacing link text with the corresponding ilw-icon component.
 
 ## External References
 

--- a/samples/index.html
+++ b/samples/index.html
@@ -24,26 +24,26 @@
 
         <nav slot="social" aria-label="Social media">
             <ul>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Bluesky account" icon="bluesky" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our events calendar account" icon="calendar" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Facebook account" icon="facebook" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Flickr account" icon="flickr" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our GitHub account" icon="github" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Instagram account" icon="instagram" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our LinkedIn account" icon="linkedin" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Mastodon account" icon="mastodon" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Pinterest account" icon="pinterest" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Reddit account" icon="reddit" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Snapchat account" icon="snapchat" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Spotify account" icon="spotify" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Threads account" icon="threads" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our TikTok account" icon="tiktok" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Twitter account" icon="twitter" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Weibo account" icon="weibo" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our WhatsApp account" icon="whatsapp" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our X account" icon="x" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Yelp account" icon="yelp" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our YouTube account" icon="youtube" size="44px"></ilw-icon></a></li>
             </ul>
         </nav>
 

--- a/samples/index.html
+++ b/samples/index.html
@@ -3,11 +3,12 @@
 
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> 
-    <meta name="viewport" content="width=device-width, initial-scale=1"> 
-    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico"> 
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico">
     <link rel="dns-prefetch" href="//cdn.toolkit.illinois.edu">
     <link rel="stylesheet" href="//cdn.toolkit.illinois.edu/3/toolkit.css">
+    <script type="module" src="//cdn.toolkit.illinois.edu/3/toolkit.js"></script>
     <script type="module" src="/src/ilw-footer.ts"></script>
     <title>Sample footer</title>
 </head>
@@ -23,26 +24,26 @@
 
         <nav slot="social" aria-label="Social media">
             <ul>
-                <li><a data-service="bluesky" href="http://example.com/">Bluesky</a></li>
-                <li><a data-service="calendar" href="http://example.com/">Calendar</a></li>
-                <li><a data-service="facebook" href="http://example.com/">Facebook</a></li>
-                <li><a data-service="flickr" href="http://example.com/">flickr</a></li>
-                <li><a data-service="github" href="http://example.com/">GitHub</a></li>
-                <li><a data-service="instagram" href="http://example.com/">Instagram</a></li>
-                <li><a data-service="linkedin" href="http://example.com/">LinkedIn</a></li>
-                <li><a data-service="mastodon" href="http://example.com/">Mastodon</a></li>
-                <li><a data-service="pinterest" href="http://example.com/">Pinterest</a></li>
-                <li><a data-service="reddit" href="http://example.com/">Reddit</a></li>
-                <li><a data-service="snapchat" href="http://example.com/">Snapchat</a></li>
-                <li><a data-service="spotify" href="http://example.com/">Spotify</a></li>
-                <li><a data-service="threads" href="http://example.com/">Threads</a></li>
-                <li><a data-service="tiktok" href="http://example.com/">TikTok</a></li>
-                <li><a data-service="twitter" href="http://example.com/">Twitter</a></li>
-                <li><a data-service="weibo" href="http://example.com/">Weibo</a></li>
-                <li><a data-service="whatsapp" href="http://example.com/">WhatsApp</a></li>
-                <li><a data-service="x" href="http://example.com/">X</a></li>
-                <li><a data-service="yelp" href="http://example.com/">Yelp</a></li>
-                <li><a data-service="youtube" href="http://example.com/">YouTube</a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
             </ul>
         </nav>
 

--- a/samples/index.html
+++ b/samples/index.html
@@ -30,7 +30,7 @@
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>

--- a/samples/multiple-primary-units.html
+++ b/samples/multiple-primary-units.html
@@ -24,26 +24,26 @@
 
         <nav slot="social" aria-label="Social media">
             <ul>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Bluesky account" icon="bluesky" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our events calendar account" icon="calendar" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Facebook account" icon="facebook" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Flickr account" icon="flickr" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our GitHub account" icon="github" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Instagram account" icon="instagram" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our LinkedIn account" icon="linkedin" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Mastodon account" icon="mastodon" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Pinterest account" icon="pinterest" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Reddit account" icon="reddit" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Snapchat account" icon="snapchat" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Spotify account" icon="spotify" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Threads account" icon="threads" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our TikTok account" icon="tiktok" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Twitter account" icon="twitter" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Weibo account" icon="weibo" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our WhatsApp account" icon="whatsapp" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our X account" icon="x" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our Yelp account" icon="yelp" size="44px"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon alt="Our YouTube account" icon="youtube" size="44px"></ilw-icon></a></li>
             </ul>
         </nav>
 

--- a/samples/multiple-primary-units.html
+++ b/samples/multiple-primary-units.html
@@ -3,11 +3,12 @@
 
 <head>
     <meta charset="utf-8">
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> 
-    <meta name="viewport" content="width=device-width, initial-scale=1"> 
-    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico"> 
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico">
     <link rel="dns-prefetch" href="//cdn.toolkit.illinois.edu">
     <link rel="stylesheet" href="//cdn.toolkit.illinois.edu/3/toolkit.css">
+    <script type="module" src="//cdn.toolkit.illinois.edu/3/toolkit.js"></script>
     <script type="module" src="/src/ilw-footer.ts"></script>
     <title>Sample footer</title>
 </head>
@@ -23,24 +24,26 @@
 
         <nav slot="social" aria-label="Social media">
             <ul>
-                <li><a data-service="bluesky" href="http://example.com/">Bluesky</a></li>
-                <li><a data-service="calendar" href="http://example.com/">Calendar</a></li>
-                <li><a data-service="facebook" href="http://example.com/">Facebook</a></li>
-                <li><a data-service="flickr" href="http://example.com/">flickr</a></li>
-                <li><a data-service="instagram" href="http://example.com/">Instagram</a></li>
-                <li><a data-service="linkedin" href="http://example.com/">LinkedIn</a></li>
-                <li><a data-service="pinterest" href="http://example.com/">Pinterest</a></li>
-                <li><a data-service="reddit" href="http://example.com/">Reddit</a></li>
-                <li><a data-service="snapchat" href="http://example.com/">Snapchat</a></li>
-                <li><a data-service="spotify" href="http://example.com/">Spotify</a></li>
-                <li><a data-service="threads" href="http://example.com/">Threads</a></li>
-                <li><a data-service="tiktok" href="http://example.com/">TikTok</a></li>
-                <li><a data-service="twitter" href="http://example.com/">Twitter</a></li>
-                <li><a data-service="weibo" href="http://example.com/">Weibo</a></li>
-                <li><a data-service="whatsapp" href="http://example.com/">WhatsApp</a></li>
-                <li><a data-service="x" href="http://example.com/">X</a></li>
-                <li><a data-service="yelp" href="http://example.com/">Yelp</a></li>
-                <li><a data-service="youtube" href="http://example.com/">YouTube</a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
             </ul>
         </nav>
 
@@ -52,8 +55,10 @@
             <p>Phone: <a href="tel:+12175551234">(217) 555-1234</a></p>
         </address>
 
-        <ul slot="primary-unit"><li><a href="/">Strategic Communications and Marketing</a></li>
-        <li><a href="/">Technology Services</a></li></ul>
+        <ul slot="primary-unit">
+            <li><a href="/">Strategic Communications and Marketing</a></li>
+            <li><a href="/">Technology Services</a></li>
+        </ul>
 
         <div slot="actions">
             <a href="/give">Give</a>

--- a/samples/multiple-primary-units.html
+++ b/samples/multiple-primary-units.html
@@ -30,7 +30,7 @@
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+                <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
                 <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>

--- a/samples/variations.html
+++ b/samples/variations.html
@@ -7,6 +7,7 @@
     <title>Footer Component</title>
     <link rel="stylesheet" href="https://cdn.brand.illinois.edu/illinois.css" />
     <link rel="stylesheet" href="https://dev.toolkit.illinois.edu/ilw-global/3.0.0-alpha/ilw-global.css" />
+    <script type="module" src="//cdn.toolkit.illinois.edu/3/toolkit.js"></script>
     <script type="module" src="../src/ilw-footer.ts"></script>
 </head>
 
@@ -21,24 +22,26 @@
 
             <nav slot="social" aria-label="Social media">
                 <ul>
-                    <li><a data-service="bluesky" href="http://example.com/">Bluesky</a></li>
-                    <li><a data-service="calendar" href="http://example.com/">Calendar</a></li>
-                    <li><a data-service="facebook" href="http://example.com/">Facebook</a></li>
-                    <li><a data-service="flickr" href="http://example.com/">flickr</a></li>
-                    <li><a data-service="instagram" href="http://example.com/">Instagram</a></li>
-                    <li><a data-service="linkedin" href="http://example.com/">LinkedIn</a></li>
-                    <li><a data-service="pinterest" href="http://example.com/">Pinterest</a></li>
-                    <li><a data-service="reddit" href="http://example.com/">Reddit</a></li>
-                    <li><a data-service="snapchat" href="http://example.com/">Snapchat</a></li>
-                    <li><a data-service="spotify" href="http://example.com/">Spotify</a></li>
-                    <li><a data-service="threads" href="http://example.com/">Threads</a></li>
-                    <li><a data-service="tiktok" href="http://example.com/">TikTok</a></li>
-                    <li><a data-service="twitter" href="http://example.com/">Twitter</a></li>
-                    <li><a data-service="weibo" href="http://example.com/">Weibo</a></li>
-                    <li><a data-service="whatsapp" href="http://example.com/">WhatsApp</a></li>
-                    <li><a data-service="x" href="http://example.com/">X</a></li>
-                    <li><a data-service="yelp" href="http://example.com/">Yelp</a></li>
-                    <li><a data-service="youtube" href="http://example.com/">YouTube</a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
                 </ul>
             </nav>
 

--- a/samples/variations.html
+++ b/samples/variations.html
@@ -22,26 +22,26 @@
 
             <nav slot="social" aria-label="Social media">
                 <ul>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Bluesky account" icon="bluesky" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our events calendar account" icon="calendar" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Facebook account" icon="facebook" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Flickr account" icon="flickr" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our GitHub account" icon="github" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Instagram account" icon="instagram" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our LinkedIn account" icon="linkedin" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Mastodon account" icon="mastodon" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Pinterest account" icon="pinterest" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Reddit account" icon="reddit" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Snapchat account" icon="snapchat" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Spotify account" icon="spotify" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Threads account" icon="threads" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our TikTok account" icon="tiktok" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Twitter account" icon="twitter" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Weibo account" icon="weibo" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our WhatsApp account" icon="whatsapp" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our X account" icon="x" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our Yelp account" icon="yelp" size="44px"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon alt="Our YouTube account" icon="youtube" size="44px"></ilw-icon></a></li>
                 </ul>
             </nav>
 

--- a/samples/variations.html
+++ b/samples/variations.html
@@ -28,7 +28,7 @@
                     <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
                     <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
                     <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+                    <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
                     <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
                     <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
                     <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>

--- a/samples/with-menus.html
+++ b/samples/with-menus.html
@@ -24,26 +24,26 @@
 
     <nav slot="social" aria-label="Social media">
       <ul>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Bluesky account" icon="bluesky" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our events calendar account" icon="calendar" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Facebook account" icon="facebook" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Flickr account" icon="flickr" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our GitHub account" icon="github" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Instagram account" icon="instagram" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our LinkedIn account" icon="linkedin" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Mastodon account" icon="mastodon" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Pinterest account" icon="pinterest" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Reddit account" icon="reddit" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Snapchat account" icon="snapchat" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Spotify account" icon="spotify" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Threads account" icon="threads" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our TikTok account" icon="tiktok" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Twitter account" icon="twitter" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Weibo account" icon="weibo" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our WhatsApp account" icon="whatsapp" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our X account" icon="x" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our Yelp account" icon="yelp" size="44px"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon alt="Our YouTube account" icon="youtube" size="44px"></ilw-icon></a></li>
       </ul>
     </nav>
 

--- a/samples/with-menus.html
+++ b/samples/with-menus.html
@@ -3,11 +3,12 @@
 
 <head>
   <meta charset="utf-8">
-  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"> 
-  <meta name="viewport" content="width=device-width, initial-scale=1"> 
-  <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico"> 
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="https://cdn.brand.illinois.edu/favicon.ico">
   <link rel="dns-prefetch" href="//cdn.toolkit.illinois.edu">
   <link rel="stylesheet" href="//cdn.toolkit.illinois.edu/3/toolkit.css">
+  <script type="module" src="//cdn.toolkit.illinois.edu/3/toolkit.js"></script>
   <script type="module" src="/src/ilw-footer.ts"></script>
   <title>Sample footer</title>
 </head>
@@ -23,24 +24,26 @@
 
     <nav slot="social" aria-label="Social media">
       <ul>
-        <li><a data-service="bluesky" href="http://example.com/">Bluesky</a></li>
-        <li><a data-service="calendar" href="http://example.com/">Calendar</a></li>
-        <li><a data-service="facebook" href="http://example.com/">Facebook</a></li>
-        <li><a data-service="flickr" href="http://example.com/">flickr</a></li>
-        <li><a data-service="instagram" href="http://example.com/">Instagram</a></li>
-        <li><a data-service="linkedin" href="http://example.com/">LinkedIn</a></li>
-        <li><a data-service="pinterest" href="http://example.com/">Pinterest</a></li>
-        <li><a data-service="reddit" href="http://example.com/">Reddit</a></li>
-        <li><a data-service="snapchat" href="http://example.com/">Snapchat</a></li>
-        <li><a data-service="spotify" href="http://example.com/">Spotify</a></li>
-        <li><a data-service="threads" href="http://example.com/">Threads</a></li>
-        <li><a data-service="tiktok" href="http://example.com/">TikTok</a></li>
-        <li><a data-service="twitter" href="http://example.com/">Twitter</a></li>
-        <li><a data-service="weibo" href="http://example.com/">Weibo</a></li>
-        <li><a data-service="whatsapp" href="http://example.com/">WhatsApp</a></li>
-        <li><a data-service="x" href="http://example.com/">X</a></li>
-        <li><a data-service="yelp" href="http://example.com/">Yelp</a></li>
-        <li><a data-service="youtube" href="http://example.com/">YouTube</a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="bluesky"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="calendar"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="facebook"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="snapchat"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="spotify"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="threads"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="tiktok"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="twitter"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="weibo"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="whatsapp"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="x"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="yelp"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="youtube"></ilw-icon></a></li>
       </ul>
     </nav>
 

--- a/samples/with-menus.html
+++ b/samples/with-menus.html
@@ -30,7 +30,7 @@
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="flickr"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="github"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="instagram"></ilw-icon></a></li>
-        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedIn"></ilw-icon></a></li>
+        <li><a href="http://example.com/"><ilw-icon size="44px" icon="linkedin"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="mastodon"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="pinterest"></ilw-icon></a></li>
         <li><a href="http://example.com/"><ilw-icon size="44px" icon="reddit"></ilw-icon></a></li>

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -142,8 +142,6 @@ ilw-footer {
             color: var(--il-blue);
             font: 700 1rem var(--il-font-sans);
             cursor: pointer;
-            width: max(22px, 2.75rem);
-            height: max(22px, 2.75rem);
             overflow: hidden;
 
             &:hover {
@@ -156,6 +154,7 @@ ilw-footer {
             background-color: var(--ilw-link--focus-background-color);
             outline: var(--ilw-link--focus-outline);
             outline-width: 0.2rem;
+            display: inline-block;
         }
 
         /** social icon data-service deprecated */

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -139,22 +139,16 @@ ilw-footer {
         a {
             all: initial;
             position: relative;
-            display: none;
             color: var(--il-blue);
             font: 700 1rem var(--il-font-sans);
             cursor: pointer;
-            background-image: var(--ilw-footer-social-icon);
             width: max(22px, 2.75rem);
             height: max(22px, 2.75rem);
             overflow: hidden;
-            background-repeat: no-repeat;
-            background-size: contain;
-            background-position: center;
-            text-indent: 33rem;
-        }
 
-        a:hover {
-            background-image: var(--ilw-footer-social-icon-hover);
+            &:hover {
+                color: var(--il-orange);
+            }
         }
 
         a:focus {
@@ -186,6 +180,15 @@ ilw-footer {
         a[data-service="yelp"],
         a[data-service="youtube"] {
             display: block;
+            background-image: var(--ilw-footer-social-icon);
+            background-repeat: no-repeat;
+            background-size: contain;
+            background-position: center;
+            text-indent: 33rem;
+            
+            &:hover {
+                background-image: var(--ilw-footer-social-icon-hover);
+            }
         }
 
         a[data-service="bluesky"] {

--- a/src/ilw-footer.css
+++ b/src/ilw-footer.css
@@ -164,6 +164,7 @@ ilw-footer {
             outline-width: 0.2rem;
         }
 
+        /** social icon data-service deprecated */
         a[data-service="bluesky"],
         a[data-service="calendar"],
         a[data-service="facebook"],
@@ -286,6 +287,7 @@ ilw-footer {
             --ilw-footer-social-icon: url("https://cdn.brand.illinois.edu/icons/solid/blue/youtube.svg");
             --ilw-footer-social-icon-hover: url("https://cdn.brand.illinois.edu/icons/solid/orange/youtube.svg");
         }
+        /** social icon data-service deprecated */
     }
 
     a[slot="actions"],

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -35,6 +35,9 @@ export class Footer extends LitElement {
   @queryAssignedElements({ slot: 'cookies-button' })
   _cookiesButton?: Array<HTMLElement>
 
+  @queryAssignedElements({ slot: 'social' })
+  _social?: Array<HTMLElement>
+
   @property({
     attribute: false
   })

--- a/src/ilw-footer.ts
+++ b/src/ilw-footer.ts
@@ -158,6 +158,18 @@ export class Footer extends LitElement {
       console.warn('No cookie banner found. Assigning standard Illinois cookie banner.')
       this.generateCookieBanner();
     }
+
+    this.checkSocialDataService(this._social);
+  }
+
+  private checkSocialDataService(social?: Array<HTMLElement>): void {
+    if (social === undefined || social.length === 0) {
+      return;
+    }
+
+    if (social.some(e => e.innerHTML.includes('data-service'))) {
+      console.warn("ilw-footer: Use of the 'data-service' attribute in social media icons is deprecated.\nSee https://github.com/web-illinois/ilw-footer/blob/main/README.md for update instructions.");
+    }
   }
 
   private generateCookieBanner(): void {


### PR DESCRIPTION
## Summary

- Add deprecation notice for social slot `data-service` attribute.
- Update recommended social media icon link method (closes #44).
- Deliver console warning if `data-service` detected in social slot.

## Testing

1. Check that new ilw-icon social icons display correctly at rest, focus, and hover.
2. Check that ilw-icon social links are accessible.
3. If possible, check that link text is not displayed over icon on iphone.
4. Using `<a href="https://example.com" data-service="github">GitHub</a>`, check that github icon is displayed and console warning is delivered.